### PR TITLE
Enable passphrase

### DIFF
--- a/main.c
+++ b/main.c
@@ -358,9 +358,11 @@ int handleoutput( int fd )
 {
     // We are looking for the string
     static int prevmatch=0; // If the "password" prompt is repeated, we have the wrong password.
-    static int state1, state2;
+    static int prevmatch2=0; // If the "passphrase" prompt is repeated, we have the wrong passphrase.
+    static int state1, state2, state3;
     static const char compare1[]="assword:"; // Asking for a password
     static const char compare2[]="The authenticity of host "; // Asks to authenticate host
+    static const char compare3[]="Enter passphrase for key "; // Asking for passphrase
     // static const char compare3[]="WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!"; // Warns about man in the middle attack
     // The remote identification changed error is sent to stderr, not the tty, so we do not handle it.
     // This is not a problem, as ssh exists immediately in such a case
@@ -381,6 +383,22 @@ int handleoutput( int fd )
 	    // Wrong password - terminate with proper error code
 	    ret=RETURN_INCORRECT_PASSWORD;
 	}
+    }
+
+    if ( ret==0 ) {
+        state3=match( compare3, buffer, numread, state3 );
+
+        // Are we being prompted for passphrase
+        if ( compare3[state3]=='\0' ) {
+        if (!prevmatch2) {
+            write_pass( fd );
+            state3=0;
+            prevmatch2=1;
+        } else {
+            // Wrong password - terminate with proper error code
+            ret=RETURN_INCORRECT_PASSWORD;
+        }
+        }
     }
 
     if( ret==0 ) {


### PR DESCRIPTION
It won't work if you use sshpass in the case of private key, such as
```
sshpass -p <my passphrase> ssh -i <my_private_key> root@myserver.mycompany.com
```

The reason it does not work is, the prompt is `Enter passphrase for key ` instead of `Password:`